### PR TITLE
Improve feed blocking

### DIFF
--- a/content_scripts/reddit.js
+++ b/content_scripts/reddit.js
@@ -1,20 +1,24 @@
 (function() {
-  const selectors = [
-    '[data-testid="frontpage-sidebar"]',
-    '[data-testid="post-container"]',
-    '[data-testid="feed-sidebar"]',
-    '.promotedlink'
-  ];
+  const allowed = ['/', '/r/popular', '/r/all'];
+
+  function onTargetPage() {
+    const path = location.pathname.replace(/\/$/, '');
+    return allowed.includes(path);
+  }
 
   function hide() {
-    selectors.forEach(s => {
-      document.querySelectorAll(s).forEach(el => {
-        el.style.display = 'none';
-      });
+    if (!onTargetPage()) {
+      return;
+    }
+    document.querySelectorAll('shreddit-feed').forEach(el => {
+      el.remove();
     });
   }
 
   const observer = new MutationObserver(hide);
-  observer.observe(document.body || document.documentElement, { childList: true, subtree: true });
+  observer.observe(document.body || document.documentElement, {
+    childList: true,
+    subtree: true
+  });
   hide();
 })();

--- a/content_scripts/youtube.js
+++ b/content_scripts/youtube.js
@@ -1,16 +1,23 @@
 (function() {
-  const selectors = [
+  const hideSelectors = [
     '#related',
     'ytd-watch-next-secondary-results-renderer',
     'ytd-merch-shelf-renderer',
-    'ytd-rich-item-renderer'
+    'ytd-rich-item-renderer',
+    'div.html5-endscreen.ytp-player-content.videowall-endscreen.ytp-show-tiles'
   ];
 
+  const removeSelectors = ['#secondary'];
+
   function hide() {
-    selectors.forEach(s => {
+    hideSelectors.forEach(s => {
       document.querySelectorAll(s).forEach(el => {
         el.style.display = 'none';
       });
+    });
+
+    removeSelectors.forEach(s => {
+      document.querySelectorAll(s).forEach(el => el.remove());
     });
   }
 


### PR DESCRIPTION
## Summary
- update Reddit script to only run on the home, r/popular and r/all pages
- remove the `shreddit-feed` element on Reddit
- hide YouTube's video wall end screen
- remove the sidebar container on YouTube watch pages

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68432d116b20832d993527b4a72e0cdd